### PR TITLE
moved CICD section and nav under AVD

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ The AVD Workshops are intended for engineers looking to learn the fundamentals o
 - [Jinja/YAML](workshops/jinja-yaml.md)
 - [Ansible](workshops/ansible.md)
 
-## AVD
+## Arista CI
 
-- [Arista Validated Designs](workshops/avd.md)
+- [AVD](workshops/avd.md)
 - [CI/CD Basics](workshops/cicd-basics.md)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ The AVD Workshops are intended for engineers looking to learn the fundamentals o
 - [VS Code](workshops/vscode.md)
 - [Jinja/YAML](workshops/jinja-yaml.md)
 - [Ansible](workshops/ansible.md)
-- [CI/CD Basics](workshops/cicd-basics.md)
 
 ## AVD
 
-- [AVD](workshops/avd.md)
+- [Arista Validated Designs](workshops/avd.md)
+- [CI/CD Basics](workshops/cicd-basics.md)
 
 ## Contributing
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,9 +11,9 @@ nav:
     - VS Code: vscode.md
     - Jinja/YAML: jinja-yaml.md
     - Ansible: ansible.md
+  - AVD:
+    - Arista Validated Designs: avd.md
     - CI/CD Basics: cicd-basics.md
-  - AVD: avd.md
-
 
 copyright: Copyright &copy; 2023 Arista Networks
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,8 +11,8 @@ nav:
     - VS Code: vscode.md
     - Jinja/YAML: jinja-yaml.md
     - Ansible: ansible.md
-  - AVD:
-    - Arista Validated Designs: avd.md
+  - Arista CI:
+    - AVD: avd.md
     - CI/CD Basics: cicd-basics.md
 
 copyright: Copyright &copy; 2023 Arista Networks

--- a/workshops/index.md
+++ b/workshops/index.md
@@ -15,7 +15,7 @@ The AVD Workshops are intended for engineers looking to learn the fundamentals o
 - [Jinja/YAML](jinja-yaml.md)
 - [Ansible](ansible.md)
 
-## AVD
+## Arista CI
 
-- [Arista Validate Designs](avd.md)
+- [AVD](avd.md)
 - [CI/CD Basics](cicd-basics.md)

--- a/workshops/index.md
+++ b/workshops/index.md
@@ -14,8 +14,8 @@ The AVD Workshops are intended for engineers looking to learn the fundamentals o
 - [VS Code](vscode.md)
 - [Jinja/YAML](jinja-yaml.md)
 - [Ansible](ansible.md)
-- [CI/CD Basics](cicd-basics.md)
 
 ## AVD
 
-- [AVD](avd.md)
+- [Arista Validate Designs](avd.md)
+- [CI/CD Basics](cicd-basics.md)


### PR DESCRIPTION
Moving CI/CD section under AVD as this is more of an advanced topic and will be covered in the AVD workshop in April.