### PR TITLE
Doc: Add note about merging PR

### DIFF
--- a/workshops/git.md
+++ b/workshops/git.md
@@ -435,9 +435,12 @@ Once all changes have been agreed upon, the maintainer of the original repo will
 
 This will generate a Pull Request on the main project repository **`aristanetworks/ci-workshops-fundamentals`**. The owner/maintainer can merge the pull request once all changes are satisfied.
 
-### **Cleanup**
+???+ note
+    During the workshop the PR is not normally merged to prevent having to reset the repo before the next workshop. The `Cleanup` section below is the normal course of action.
 
-After merging a Pull Request, you may cleanup your old branch.
+### **Cleanup** _(optional)_
+
+After your Pull Request is merged, you may cleanup your old branch and sync your fork.
 
 1. Delete your branch on GitHub and your local host.
 2. Sync your Forked repo (below)

--- a/workshops/git.md
+++ b/workshops/git.md
@@ -438,7 +438,7 @@ This will generate a Pull Request on the main project repository **`aristanetwor
 ???+ note
     During the workshop the PR is not normally merged to prevent having to reset the repo before the next workshop. The `Cleanup` section below is the normal course of action.
 
-### **Cleanup** _(optional)_
+### **Cleanup** *(optional)*
 
 After your Pull Request is merged, you may cleanup your old branch and sync your fork.
 


### PR DESCRIPTION
At the bottom of the Git section, a note was added to make merging the PR optional to prevent having to reset the repo and state what normally happens vs actually doing it.

Resolves #91 