### PR TITLE
Docs(Git): split code block

### DIFF
--- a/workshops/git.md
+++ b/workshops/git.md
@@ -340,9 +340,13 @@ cd ci-workshops-fundamentals
 
 Verify the location of the remote copy. This should be your local GitHub account.
 
-``` bash hl_lines="3-4"
+``` bash
 git remote -v
+```
 
+Output:
+
+``` text
 origin  https://github.com/xxxxxxx/ci-workshops-fundamentals.git (fetch)
 origin  https://github.com/xxxxxxx/ci-workshops-fundamentals.git (push)
 ```


### PR DESCRIPTION
Split Code block into 2 separate blocks.  Fixes Issue #94 

Currently:

```
git remote -v

origin  https://github.com/xxxxxxx/ci-workshops-fundamentals.git (fetch)
origin  https://github.com/xxxxxxx/ci-workshops-fundamentals.git (push)
```

Proposed fix:

```
git remote -v
```

Output:

```
origin  https://github.com/xxxxxxx/ci-workshops-fundamentals.git (fetch)
origin  https://github.com/xxxxxxx/ci-workshops-fundamentals.git (push)
```


