### PR TITLE
Hard coding the ansible-core version

### DIFF
--- a/workshops/avd-lab-guide.md
+++ b/workshops/avd-lab-guide.md
@@ -52,14 +52,15 @@ git config --global user.name "FirstName LastName"
 git config --global user.email "name@example.com"
 ```
 
-### STEP #3 - Update AVD to the latest version
+### STEP #3 - Update AVD
 
-AVD has been pre-installed in your lab environment. However, it may be on an older version. The following steps will update AVD and modules to the latest versions.
+AVD has been pre-installed in your lab environment. However, it may be on an older version (in some cases a newer version). The following steps will update AVD and modules to the valid versions for the lab.
 
 ``` bash
+pip3 config set global.disable-pip-version-check true
+pip3 install "ansible-core<2.15.0"
 ansible-galaxy collection install -r requirements.yml
 export ARISTA_AVD_DIR=$(ansible-galaxy collection list arista.avd --format yaml | head -1 | cut -d: -f1)
-pip3 config set global.disable-pip-version-check true
 pip3 install -r ${ARISTA_AVD_DIR}/arista/avd/requirements.txt
 ```
 

--- a/workshops/avd.md
+++ b/workshops/avd.md
@@ -26,15 +26,16 @@ Attendees will need the following:
 The ATD lab environment was provisioned with Ansible and Git. First, however, we must update AVD and the required modules to the latest version. The following commands will install AVD and the needed modules.
 
 ``` bash
-ansible-galaxy collection install arista.avd arista.cvp --force
-export ARISTA_AVD_DIR=$(ansible-galaxy collection list arista.avd --format yaml | head -1 | cut -d: -f1)
 pip3 config set global.disable-pip-version-check true
+pip3 install "ansible-core<2.15.0"
+ansible-galaxy collection install -r requirements.yml
+export ARISTA_AVD_DIR=$(ansible-galaxy collection list arista.avd --format yaml | head -1 | cut -d: -f1)
 pip3 install -r ${ARISTA_AVD_DIR}/arista/avd/requirements.txt
 ```
 
 ???+ Note
 
-    IMPORTANT: The above steps must be run each time you start your lab.
+    IMPORTANT: The installation steps assume the [repository](https://github.com/aristanetworks/ci-workshops-avd) has already been forked and cloned to the IDE. The above steps must be run each time you start your lab.
 
 ### Other Environments
 

--- a/workshops/cicd-basics.md
+++ b/workshops/cicd-basics.md
@@ -31,39 +31,6 @@ export ARISTA_AVD_DIR=$(ansible-galaxy collection list arista.avd --format yaml 
 pip3 install -r ${ARISTA_AVD_DIR}/arista/avd/requirements.txt
 ```
 
-### ATD programmability IDE installation
-
-You can ensure the appropriate AVD version is installed by running the following command.
-
-```shell
-ansible-galaxy collection list
-```
-
-```shell hl_lines="9"
-➜  ci-workshops-avd git:(main) ansible-galaxy collection list
-
-# /home/coder/.ansible/collections/ansible_collections
-Collection        Version
------------------ -------
-ansible.netcommon 4.1.0
-ansible.posix     1.4.0
-ansible.utils     2.8.0
-arista.avd        4.1.0
-arista.cvp        3.6.1
-arista.eos        6.0.0
-community.general 6.2.0
-➜  ci-workshops-avd git:(main)
-```
-
-If AVD version `4.0.0` or greater is not present, please upgrade to the latest stable version.
-
-```shell
-ansible-galaxy collection install -r requirements.yml
-export ARISTA_AVD_DIR=$(ansible-galaxy collection list arista.avd --format yaml | head -1 | cut -d: -f1)
-pip3 config set global.disable-pip-version-check true
-pip3 install -r ${ARISTA_AVD_DIR}/arista/avd/requirements.txt
-```
-
 ## Fork and clone the repository
 
 You will be creating your own CI/CD pipeline in this workflow. Log in to your GitHub account and fork the [`ci-workshops-avd`](https://github.com/aristanetworks/ci-workshops-avd/) repository to get started.
@@ -98,6 +65,40 @@ You will be creating your own CI/CD pipeline in this workflow. Log in to your Gi
    ```shell
    git config --global user.email "name@example.com"
    ```
+
+### ATD programmability IDE installation
+
+You can check the current AVD version by running the following command:
+
+```shell
+ansible-galaxy collection list
+```
+
+```shell hl_lines="9"
+➜  ci-workshops-avd git:(main) ansible-galaxy collection list
+
+# /home/coder/.ansible/collections/ansible_collections
+Collection        Version
+----------------- -------
+ansible.netcommon 4.1.0
+ansible.posix     1.4.0
+ansible.utils     2.8.0
+arista.avd        4.1.0
+arista.cvp        3.6.1
+arista.eos        6.0.0
+community.general 6.2.0
+➜  ci-workshops-avd git:(main)
+```
+
+Run the following commands to install the required packages within the ATD environment.
+
+```shell
+pip3 config set global.disable-pip-version-check true
+pip3 install "ansible-core<2.15.0"
+ansible-galaxy collection install -r requirements.yml
+export ARISTA_AVD_DIR=$(ansible-galaxy collection list arista.avd --format yaml | head -1 | cut -d: -f1)
+pip3 install -r ${ARISTA_AVD_DIR}/arista/avd/requirements.txt
+```
 
 ### Fast-forward the main brach
 


### PR DESCRIPTION
Latest push to the ATD environment sets the ansible-core version to 2.15.5 which is not compatible with AVD 4.1.0, another update will be required to update the workshops to 4.4.0