### PR TITLE
Feat: Add GitHub Cli to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
 	"name": "avd-workshops",
 	"context": ".",
 	"features": {
-		"ghcr.io/shinepukur/devcontainer-features/vale:1": {}
+		"ghcr.io/shinepukur/devcontainer-features/vale:1": {},
+        "ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 	"workspaceFolder": "/workspace",
 	"dockerComposeFile": "docker-compose.yml",


### PR DESCRIPTION
Add GitHub Cli to extension to devcontainer.  No other changes.  Users will need to rebuild container
to take activate it.

