### PR TITLE
Docs - Git switch -c shortcut note

### DIFF
--- a/workshops/git.md
+++ b/workshops/git.md
@@ -355,6 +355,8 @@ In the next step, let's add VLAN 40 to the data model in `avd/vlans.yml`. First,
 
 ### **Create and switch to a new branch**
 
+???+ note Want to save some time and shortcut creating and switching to a branch? Try `git switch -c add-vlan-40` for those two steps.
+
 ``` bash
 git branch add-vlan-40
 git switch add-vlan-40

--- a/workshops/git.md
+++ b/workshops/git.md
@@ -355,7 +355,7 @@ In the next step, let's add VLAN 40 to the data model in `avd/vlans.yml`. First,
 
 ### **Create and switch to a new branch**
 
-???+ note Want to save some time and shortcut creating and switching to a branch? Try `git switch -c add-vlan-40` for those two steps.
+???+ note Want to save some time by shortcutting the creation and switch to a branch? Try `git switch -c add-vlan-40` for those two actions in one command.
 
 ``` bash
 git branch add-vlan-40


### PR DESCRIPTION
During the live virtual workshop, @mthiel117 mentioned creating and switching to a branch in one command. We're busy professionals so it is nice to have some time saving shortcuts (if we can call this that).

I'm suggesting adding a note which shares the two-in-one syntax for `git switch -c <branch>` in a later section (when modifying vlans.yml) after students have learned the two-step process of `git branch` and `git switch`.