### PR TITLE
Docs: Enhance avd-lab-guide and cicd-basics wording and command

### DIFF
--- a/workshops/avd-lab-guide.md
+++ b/workshops/avd-lab-guide.md
@@ -73,7 +73,7 @@ pip3 install -r ${ARISTA_AVD_DIR}/arista/avd/requirements.txt
 Each lab comes with a unique password. We set an environment variable called `LABPASSPHRASE` with the following command. The variable is later used to generate local user passwords and connect to our switches to push configs.
 
 ``` bash
-export LABPASSPHRASE=`cat /home/coder/.config/code-server/config.yaml| grep "password:" | awk '{print $2}'`
+export LABPASSPHRASE=`awk '/password:/{print $2}' /home/coder/.config/code-server/config.yaml`
 ```
 
 You can view the password is set. This is the same password displayed when you click the link to access your lab.

--- a/workshops/avd-lab-guide.md
+++ b/workshops/avd-lab-guide.md
@@ -54,7 +54,7 @@ git config --global user.email "name@example.com"
 
 ### Update AVD
 
-AVD has been pre-installed in your lab environment. However, it may be on an older version (in some cases a newer version). The following steps will update AVD and modules to the valid versions for the lab.
+AVD has been pre-installed in your lab environment. However, it may be on an older (or newer) version than intended for the lab. The following steps will update AVD and modules to the valid versions for the lab.
 
 ``` bash
 pip3 config set global.disable-pip-version-check true

--- a/workshops/avd-lab-guide.md
+++ b/workshops/avd-lab-guide.md
@@ -138,7 +138,7 @@ Now, deploy the configurations to Site 1 switches.
 make deploy-site-1
 ```
 
-Login to your switches to verify the current configs (`show run`) match the ones created in `intended/configs` folder.
+Log into your switches to verify the current configs (`show run`) match the ones created in `intended/configs` folder.
 
 You can also check the current state for MLAG, VLANs, interfaces, and port-channels.
 

--- a/workshops/avd-lab-guide.md
+++ b/workshops/avd-lab-guide.md
@@ -651,7 +651,7 @@ to the spines.
 On the spines, interface `Ethernet9` will be used to connect to s1-leaf5, while `Ethernet10`
 will be used to connect to s1-leaf6.
 
-Starting at line 64, add the following code block into `sites/site_1/group_vars/SITE1_FABRIC.yml`.
+Starting at line 69, add the following code block into `sites/site_1/group_vars/SITE1_FABRIC.yml`.
 
 ``` yaml
 - group: RACK3
@@ -667,7 +667,7 @@ Starting at line 64, add the following code block into `sites/site_1/group_vars/
 ```
 
 ???+ warning
-    Make sure the indentation of `RACK3` is the same as `RACK2`, which can be found on line 52
+    Make sure the indentation of `RACK3` is the same as `RACK2`, which can be found on line 57
 
 The `sites/site_1/group_vars/SITE1_FABRIC.yml` file should now look like the example below:
 

--- a/workshops/cicd-basics.md
+++ b/workshops/cicd-basics.md
@@ -132,7 +132,7 @@ Each lab comes with a unique password. We set an environment variable called `LA
     You can skip this step if you are continuing from the AVD workshop.
 
 ```shell
-export LABPASSPHRASE=`cat /home/coder/.config/code-server/config.yaml| grep "password:" | awk '{print $2}'`
+export LABPASSPHRASE=`awk '/password:/{print $2}' /home/coder/.config/code-server/config.yaml`
 ```
 
 ## **Step 5 - Configure the IP Network**
@@ -819,5 +819,5 @@ Congratulations, you have successfully deployed a CI/CD pipeline with GitHub Act
     You must also set the `LABPASSPHRASE` environment variable in the IDE terminal.
 
     ```shell
-    export LABPASSPHRASE=`cat /home/coder/.config/code-server/config.yaml| grep "password:" | awk '{print $2}'`
+    export LABPASSPHRASE=`awk '/password:/{print $2}' /home/coder/.config/code-server/config.yaml`
     ```

--- a/workshops/cicd-basics.md
+++ b/workshops/cicd-basics.md
@@ -288,7 +288,7 @@ jobs:
         run: echo "Hello World!"
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 ...
 ```
 
@@ -336,10 +336,10 @@ Finally, the setup Python and install requirements action above the pre-commit s
         run: echo "Hello World!"
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
 
       - name: Install Python requirements
         run: pip3 install requirements.txt
@@ -431,7 +431,7 @@ Currently, our workflow will build and deploy configurations for both sites. Thi
         uses: pre-commit/action@v3.0.0
 
       - name: Check paths for sites/site_1
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter-site1
         with:
           filters: |
@@ -439,7 +439,7 @@ Currently, our workflow will build and deploy configurations for both sites. Thi
               - 'sites/site_1/**'
 
       - name: Check paths for sites/site_2
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter-site2
         with:
           filters: |
@@ -490,10 +490,10 @@ At this point, make sure both workflow files (`dev.yml` and `prod.yml`) within t
             run: echo "Hello World!"
 
           - name: Checkout
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           - name: Setup Python
-            uses: actions/setup-python@v3
+            uses: actions/setup-python@v5
 
           - name: Install Python requirements
             run: pip3 install -r requirements.txt
@@ -502,7 +502,7 @@ At this point, make sure both workflow files (`dev.yml` and `prod.yml`) within t
             uses: pre-commit/action@v3.0.0
 
           - name: Check paths for sites/site_1
-            uses: dorny/paths-filter@v2
+            uses: dorny/paths-filter@v3
             id: filter-site1
             with:
               filters: |
@@ -510,7 +510,7 @@ At this point, make sure both workflow files (`dev.yml` and `prod.yml`) within t
                   - 'sites/site_1/**'
 
           - name: Check paths for sites/site_2
-            uses: dorny/paths-filter@v2
+            uses: dorny/paths-filter@v3
             id: filter-site2
             with:
               filters: |
@@ -748,10 +748,10 @@ jobs:
         run: echo "Hello World!"
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
 
       - name: Install Python requirements
         run: pip3 install -r requirements.txt
@@ -760,7 +760,7 @@ jobs:
         uses: pre-commit/action@v3.0.0
 
       - name: Check paths for sites/site_1
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter-site1
         with:
           filters: |
@@ -768,7 +768,7 @@ jobs:
               - 'sites/site_1/**'
 
       - name: Check paths for sites/site_2
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter-site2
         with:
           filters: |


### PR DESCRIPTION
Docs: Enhance avd-lab-guide and cicd-basics wording and command

- update GitHub Actions versions due to Node.js 16 deprecation
- shorten/simplify the command string used to set LABPASSPHRASE environment variable
- update line number references
- couple of instances of wording/grammar

Thank you for the feedback on issues #148, #150, #151