### PR TITLE
Additional Pip config for PEP 668

### DIFF
--- a/workshops/avd-lab-guide.md
+++ b/workshops/avd-lab-guide.md
@@ -57,6 +57,7 @@ git config --global user.email "name@example.com"
 AVD has been pre-installed in your lab environment. However, it may be on an older version (in some cases a newer version). The following steps will update AVD and modules to the valid versions for the lab.
 
 ``` bash
+pip3 config set global.break-system-packages true
 pip3 config set global.disable-pip-version-check true
 pip3 install "ansible-core==2.15.5"
 ansible-galaxy collection install -r requirements.yml

--- a/workshops/avd.md
+++ b/workshops/avd.md
@@ -26,6 +26,7 @@ Attendees will need the following:
 The ATD lab environment was provisioned with Ansible and Git. First, however, we must update AVD and the required modules to the latest version. The following commands will install AVD and the needed modules.
 
 ``` bash
+pip3 config set global.break-system-packages true
 pip3 config set global.disable-pip-version-check true
 pip3 install "ansible-core==2.15.5"
 ansible-galaxy collection install -r requirements.yml


### PR DESCRIPTION
Required since we do not use virtual envs in the ATD labs. Long term fix would be to add the following to the coder pip configuration.

```shell
➜  labfiles cat /home/coder/.config/pip/pip.conf                 
[global]
break-system-packages = true
disable-pip-version-check = true
```