### PR TITLE
Fixed Typo in ansible.md

### DIFF
--- a/workshops/ansible.md
+++ b/workshops/ansible.md
@@ -352,7 +352,7 @@ We can verify this by running `ansible-inventory --host s2-spine1 --yaml`.
 ansible-inventory --host s2-spine1 --yaml
 ```
 
-??? eos-config annotate "Output of 'ansible-inventory --host s1-spine1 --yaml'"
+??? eos-config annotate "Output of 'ansible-inventory --host s2-spine1 --yaml'"
     ```yaml
 
     ansible_connection: ansible.netcommon.httpapi


### PR DESCRIPTION
There is a typo in the Ansible section. 

`Output of 'ansible-inventory --host s1-spine1 --yaml`  this should be for s2-spine1 and not for s1-spine1. 